### PR TITLE
fixes for infortrend disks check

### DIFF
--- a/infortrend/checks/infortrend_disks
+++ b/infortrend/checks/infortrend_disks
@@ -17,15 +17,21 @@
 # to the Free Software Foundation, Inc., 51 Franklin St,  Fifth Floor,
 # Boston, MA 02110-1301 USA.
 
-snmp_scan_functions['infortrend_disks'] = lambda oid: oid(".1.3.6.1.4.1.1714.1.6.1.11") != None
+snmp_scan_functions['infortrend_disks'] = lambda oid: oid(".1.3.6.1.4.1.1714.1.1.6.1.11") != None
 
-snmp_info['infortrend_disks'] = ( ".1.3.6.1.4.1.1714.1.6.1", [ "13", "11" ] )
+snmp_info['infortrend_disks'] = ( ".1.3.6.1.4.1.1714.1.1.6.1", [ "13", "11" ] )
 
 def inventory_infortrend_disks(info):
     # Debug: lets see how the data we get looks like
     inventory = []
+    disknumber = 0
     for slot, status in info:
-        inventory.append( (slot, int(status)) )
+        if int(slot) != 0:
+            if int(slot) > int(disknumber):
+	        disknumber = int(slot)
+	    else:
+	        disknumber = int(disknumber) + 1
+            inventory.append( (str(disknumber), int(status)) )
     return inventory
 
 def check_infortrend_disks(item, params, info):
@@ -63,7 +69,16 @@ def check_infortrend_disks(item, params, info):
         254 : "Missing Drive",
         255 : "Failed Drive"
         }
+    disknumber = 0
+    new_info = []
     for slot, status in info:
+        if int(slot) != 0:
+	    if int(slot) > int(disknumber):
+	        disknumber = int(slot)
+	    else:
+	        disknumber = int(disknumber) + 1
+	    new_info.append([str(disknumber), str(status)])
+    for slot, status in new_info:
         status = int(status)
         if slot == item:
             if status not in status_info.keys():


### PR DESCRIPTION
fixed wrong oid.

fix disk discovery & check for infortrend boxes with JBOD extensions:
we have some infortrend boxes with JBOD extension, these where missing the disk checks due that the disk number goes back to 0 instead of counting it the right way.

remove disk slot 0 (which is no valid disk slot).
