### PR TITLE
Fix for the modified output of ceph v12.2

### DIFF
--- a/ceph/checks/ceph
+++ b/ceph/checks/ceph
@@ -34,7 +34,13 @@ def check_ceph(item, params, info):
     for line in info:
         if line[0] == 'cluster':
             text.append('Cluster %s' % line[1])
+        if line[0] == 'id:':
+            text.append('Cluster %s' % line[1])
         if line[0] == 'health':
+            text.append(' '.join(line[1:]))
+            if line[1] != 'HEALTH_OK':
+                rc = 2
+        if line[0] == 'health:':
             text.append(' '.join(line[1:]))
             if line[1] != 'HEALTH_OK':
                 rc = 2
@@ -42,6 +48,18 @@ def check_ceph(item, params, info):
             text.append(' '.join(line))
             used = saveint(line[0]) * factor[line[1]]
             size = saveint(line[6]) * factor[line[7]]
+            warn = 0.8 * size
+            crit = 0.9 * size
+            perfdata.append(("Used", "%dB" % used, warn, crit, 0, size))
+            if rc == 0:
+                if used > crit:
+                    rc = 2
+                elif used > warn:
+                    rc = 1
+        if line[0] == 'usage:':
+            text.append(' '.join(line[1:]))
+            used = saveint(line[1]) * factor[line[2]]
+            size = saveint(line[7]) * factor[line[8]]
             warn = 0.8 * size
             crit = 0.9 * size
             perfdata.append(("Used", "%dB" % used, warn, crit, 0, size))


### PR DESCRIPTION
The output of /usr/bin/ceph -s has changed with ceph version 12.2.0. With this patch the test searches for the new fields and uses them if available.

>   cluster:
    id:     63b215c4-1240-42f3-83fa-feb0d06089a8
    health: HEALTH_OK
> 
>  services:
    mon: 3 daemons, quorum 4,0,1
    mgr: ceph3(active), standbys: ceph2, ceph1
    osd: 20 osds: 20 up, 20 in
> 
>  data:
    pools:   1 pools, 512 pgs
    objects: 3816k objects, 14564 GB
    usage:   30221 GB used, 16324 GB / 46545 GB avail
    pgs:     512 active+clean
> 
>  io:
    client:   9526 kB/s rd, 1443 kB/s wr, 593 op/s rd, 90 op/s wr
 

